### PR TITLE
Embeddable BBNs

### DIFF
--- a/bayesian/utils.py
+++ b/bayesian/utils.py
@@ -17,7 +17,10 @@ def get_args(func):
     '''
     if hasattr(func, 'argspec'):
         return func.argspec
-    return inspect.getargspec(func).args
+    output = inspect.getargspec(func).args
+    if 'self' in output:
+        output.remove('self')
+    return output
 
 
 def make_key(*args):


### PR DESCRIPTION
Edited the code to elide the 'self' keyword, if present, from the arguments of a node function passed to the build() method. This allows to incorporate such functions inside a class, for example to model a specific BBN.